### PR TITLE
quirks: add support without udev

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -375,6 +375,8 @@ src_libinput = src_libfilter + [
 	'src/evdev-tablet-pad.c',
 	'src/evdev-tablet-pad.h',
 	'src/evdev-tablet-pad-leds.c',
+	'src/evdev-type.c',
+	'src/evdev-type.h',
 	'src/netlink-seat.c',
 	'src/netlink-seat.h',
 	'src/path-seat.c',

--- a/meson.build
+++ b/meson.build
@@ -339,7 +339,7 @@ src_libquirks = [
 	'src/builddir.h',
 ]
 
-deps_libquirks = [dep_udev, dep_libwacom, dep_libinput_util]
+deps_libquirks = [dep_udev, dep_libwacom, dep_libinput_util, dep_libevdev]
 libquirks = static_library('quirks', src_libquirks,
 			   dependencies : deps_libquirks,
 			   include_directories : includes_include)

--- a/src/evdev-mt-touchpad-thumb.c
+++ b/src/evdev-mt-touchpad-thumb.c
@@ -418,7 +418,11 @@ tp_init_thumb(struct tp_dispatch *tp)
 	tp->thumb.lower_thumb_line = edges.y;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 
 	if (libevdev_has_event_code(device->evdev, EV_ABS, ABS_MT_PRESSURE)) {
 		if (quirks_get_uint32(q,

--- a/src/evdev-mt-touchpad.c
+++ b/src/evdev-mt-touchpad.c
@@ -3219,7 +3219,11 @@ tp_is_tpkb_combo_below(struct evdev_device *device)
 	int rc = false;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q)
 		return false;
 
@@ -3301,7 +3305,11 @@ tp_read_palm_pressure_prop(struct tp_dispatch *tp,
 	struct quirks *q;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q)
 		return threshold;
 
@@ -3337,7 +3345,11 @@ tp_init_palmdetect_size(struct tp_dispatch *tp,
 	uint32_t threshold;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q)
 		return;
 
@@ -3531,7 +3543,11 @@ tp_init_pressure(struct tp_dispatch *tp,
 	assert(abs);
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (q && quirks_get_range(q, QUIRK_ATTR_PRESSURE_RANGE, &r)) {
 		hi = r.upper;
 		lo = r.lower;
@@ -3587,7 +3603,11 @@ tp_init_touch_size(struct tp_dispatch *tp,
 	}
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (q && quirks_get_range(q, QUIRK_ATTR_TOUCH_SIZE_RANGE, &r)) {
 		hi = r.upper;
 		lo = r.lower;

--- a/src/evdev-tablet.c
+++ b/src/evdev-tablet.c
@@ -1089,7 +1089,11 @@ tool_set_pressure_thresholds(struct tablet_dispatch *tablet,
 		goto out;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 
 	tool->pressure.offset = pressure->minimum;
 
@@ -2400,7 +2404,11 @@ tablet_init_smoothing(struct evdev_device *device,
 	bool use_smoothing = true;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 
 	/* By default, always enable smoothing except on AES devices.
 	 * AttrTabletSmoothing can override this, if necessary.

--- a/src/evdev-type.c
+++ b/src/evdev-type.c
@@ -1,0 +1,80 @@
+#include <stdint.h>
+#include <libevdev/libevdev.h>
+
+#include "evdev-type.h"
+#include "linux/input.h"
+
+uint32_t get_input_type(struct libevdev *evdev)
+{
+	uint32_t type = 0;
+	unsigned long bit;
+
+	if (libevdev_has_property(evdev, INPUT_PROP_POINTING_STICK)) {
+		type |= EVDEV_TYPE_POINTING_STICK;
+	}
+
+	if (libevdev_has_property(evdev, INPUT_PROP_ACCELEROMETER)) {
+		type |= EVDEV_TYPE_ACCELEROMETER;
+	}
+
+	if (libevdev_has_event_type(evdev, EV_SW)) {
+		type |= EVDEV_TYPE_SWITCH;
+	}
+
+	if (libevdev_has_event_type(evdev, EV_REL)) {
+		if (libevdev_has_event_code(evdev, EV_REL, REL_Y) &&
+		    libevdev_has_event_code(evdev, EV_REL, REL_X) &&
+		    libevdev_has_event_code(evdev, EV_KEY, BTN_MOUSE)) {
+			type |= EVDEV_TYPE_MOUSE;
+		}
+	}
+	else if (libevdev_has_event_type(evdev, EV_ABS)) {
+		if (libevdev_has_event_code(evdev, EV_KEY, BTN_SELECT) ||
+		    libevdev_has_event_code(evdev, EV_KEY, BTN_TR) ||
+		    libevdev_has_event_code(evdev, EV_KEY, BTN_START) ||
+		    libevdev_has_event_code(evdev, EV_KEY, BTN_TL)) {
+			if (libevdev_has_event_code(evdev, EV_KEY, BTN_TOUCH)) {
+				type |= EVDEV_TYPE_TOUCHSCREEN;
+			}
+			else {
+				type |= EVDEV_TYPE_JOYSTICK;
+			}
+		}
+		else if (libevdev_has_event_code(evdev, EV_ABS, ABS_Y) &&
+			 libevdev_has_event_code(evdev, EV_ABS, ABS_X)) {
+			if (libevdev_has_event_code(evdev, EV_ABS, ABS_Z) &&
+			    !libevdev_has_event_type(evdev, EV_KEY)) {
+				type |= EVDEV_TYPE_ACCELEROMETER;
+			}
+			else if (libevdev_has_event_code(evdev, EV_KEY, BTN_STYLUS) ||
+				 libevdev_has_event_code(evdev, EV_KEY, BTN_TOOL_PEN)) {
+				type |= EVDEV_TYPE_TABLET;
+			}
+			else if (libevdev_has_event_code(evdev, EV_KEY, BTN_TOUCH)) {
+				if (libevdev_has_event_code(evdev, EV_KEY, BTN_TOOL_FINGER)) {
+					type |= EVDEV_TYPE_TOUCHPAD;
+				}
+				else {
+					type |= EVDEV_TYPE_TOUCHSCREEN;
+				}
+			}
+			else if (libevdev_has_event_code(evdev, EV_KEY, BTN_MOUSE)) {
+				type |= EVDEV_TYPE_MOUSE;
+			}
+		}
+	}
+
+	for (bit = KEY_ESC; bit < BTN_MISC; bit++) {
+		if (libevdev_has_event_code(evdev, EV_KEY, bit)) {
+			type |= EVDEV_TYPE_KEY;
+
+			if (libevdev_has_event_code(evdev, EV_KEY, KEY_ENTER)) {
+				type |= EVDEV_TYPE_KEYBOARD;
+			}
+
+			break;
+		}
+	}
+
+	return type ? type : EVDEV_TYPE_UNKNOWN;
+}

--- a/src/evdev-type.h
+++ b/src/evdev-type.h
@@ -1,0 +1,18 @@
+#include <stdint.h>
+#include <libevdev/libevdev.h>
+
+enum {
+	EVDEV_TYPE_UNKNOWN = 1 << 0,
+	EVDEV_TYPE_MOUSE = 1 << 1,
+	EVDEV_TYPE_TABLET = 1 << 2,
+	EVDEV_TYPE_TOUCHPAD = 1 << 3,
+	EVDEV_TYPE_KEYBOARD = 1 << 4,
+	EVDEV_TYPE_JOYSTICK = 1 << 5,
+	EVDEV_TYPE_TOUCHSCREEN = 1 << 6,
+	EVDEV_TYPE_SWITCH = 1 << 7,
+	EVDEV_TYPE_ACCELEROMETER = 1 << 8,
+	EVDEV_TYPE_POINTING_STICK = 1 << 9,
+	EVDEV_TYPE_KEY = 1 << 10,
+};
+
+uint32_t get_input_type(struct libevdev *evdev);

--- a/src/evdev.c
+++ b/src/evdev.c
@@ -529,7 +529,11 @@ evdev_tag_trackpoint(struct evdev_device *device,
 	device->tags |= EVDEV_TAG_TRACKPOINT;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (q && quirks_get_string(q, QUIRK_ATTR_TRACKPOINT_INTEGRATION, &prop)) {
 		if (streq(prop, "internal")) {
 			/* noop, this is the default anyway */
@@ -581,7 +585,11 @@ evdev_tag_keyboard(struct evdev_device *device,
 	}
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (q && quirks_get_string(q, QUIRK_ATTR_KEYBOARD_INTEGRATION, &prop)) {
 		if (streq(prop, "internal")) {
 			evdev_tag_keyboard_internal(device);
@@ -1013,7 +1021,11 @@ evdev_read_switch_reliability_prop(struct evdev_device *device)
 	char *prop;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q || !quirks_get_string(q, QUIRK_ATTR_LID_SWITCH_RELIABILITY, &prop)) {
 		r = RELIABILITY_UNKNOWN;
 	} else if (!parse_switch_reliability_property(prop, &r)) {
@@ -1427,7 +1439,11 @@ evdev_get_trackpoint_multiplier(struct evdev_device *device)
 		return 1.0;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (q) {
 		quirks_get_double(q, QUIRK_ATTR_TRACKPOINT_MULTIPLIER, &multiplier);
 		quirks_unref(q);
@@ -1456,7 +1472,11 @@ evdev_need_velocity_averaging(struct evdev_device *device)
 	bool use_velocity_averaging = false; /* default off unless we have quirk */
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (q) {
 		quirks_get_bool(q,
 				QUIRK_ATTR_USE_VELOCITY_AVERAGING,
@@ -1528,7 +1548,11 @@ evdev_read_model_flags(struct evdev_device *device)
 	struct quirks *q;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 
 	while (q && m->quirk) {
 		bool is_set;
@@ -1595,7 +1619,11 @@ evdev_read_attr_res_prop(struct evdev_device *device,
 	bool rc = false;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q)
 		return false;
 
@@ -1621,7 +1649,11 @@ evdev_read_attr_size_prop(struct evdev_device *device,
 	bool rc = false;
 
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q)
 		return false;
 
@@ -2203,7 +2235,11 @@ evdev_pre_configure_model_quirks(struct evdev_device *device)
 	 * unnecessary wakeups but on some devices we need to watch it for
 	 * pointer jumps */
 	quirks = evdev_libinput_context(device)->quirks;
+#if HAVE_UDEV
 	q = quirks_fetch_for_device(quirks, device->udev_device);
+#else
+	q = quirks_fetch_for_evdev(quirks, device->evdev);
+#endif
 	if (!q ||
 	    !quirks_get_string(q, QUIRK_ATTR_MSC_TIMESTAMP, &prop) ||
 	    !streq(prop, "watch")) {

--- a/src/quirks.h
+++ b/src/quirks.h
@@ -27,6 +27,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <libevdev/libevdev.h>
 
 #include "libinput.h"
 
@@ -192,6 +193,10 @@ quirks_context_ref(struct quirks_context *ctx);
 struct quirks *
 quirks_fetch_for_device(struct quirks_context *ctx,
 			struct udev_device *device);
+
+struct quirks *
+quirks_fetch_for_evdev(struct quirks_context *ctx,
+		       struct libevdev *evdev);
 
 /**
  * Reduce the refcount by one. When the refcount reaches zero, the


### PR DESCRIPTION
This PR adds udev-less support for quirks and also fixes some issues with input detection. Namely, my touchpad and WMI keys don't work without this PR.